### PR TITLE
Added support for XML/JSON

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ to standard out. It uses JSONStream to transform the objects into JSON on the fl
     var config = {
         connections : {
             "default" : {
-                server  : "localhost"
+                server  : "localhost",
                 userName: "user",
                 password: "pass"
             }

--- a/index.js
+++ b/index.js
@@ -102,9 +102,15 @@ function StreamSqlRequest(query) {
 
     function TdsRow(columns) {
         var rowObj = {};
-        columns.forEach(function(column) {
-            rowObj[column.metadata.colName] = column.value;
-        });
+        if (columns.length == 1 &&
+                (columns[0].metadata.colName == "JSON_F52E2B61-18A1-11d1-B105-00805F49916B" 
+                || columns[0].metadata.colName == "XML_F52E2B61-18A1-11d1-B105-00805F49916B")) {
+            rowObj = columns[0].value;
+        } else {
+            columns.forEach(function (column) {
+                rowObj[column.metadata.colName] = column.value;
+            });
+        }
         responseStream.push(rowObj);
     }
 


### PR DESCRIPTION
SQL queries with FOR JSON/FOR XML clause need special handling. SQL
Server will return one-column result with a set of fragments that
represent output XML/JSON. This one-column result set has special
columns with fixed names JSON_F52E2B61-18A1-11d1-B105-00805F49916B.
SSMS, SSDT ant other tools check this criterion to determine does SLQ
Server returns XML or JSON.
